### PR TITLE
feat(editor): add F7 toggle for spell-check (refs #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.5] - 2026-04-27
+
+### Added
+
+- Status bar now shows `spellcheck:on` / `spellcheck:off` indicator. Thanks, [@chioloenrico](https://github.com/chioloenrico)!
+- Git status widget is hidden when not in a git repository, preventing a phantom gap in the status bar.
+- Status bar spacing relies entirely on CSS margins for consistency.
+
 ## [1.4.4] - 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The manuscript is read-only in Prosaic — edit your chapters, not the manuscrip
 | Editor | `F1` | Help |
 | Editor | `F5` | Focus mode |
 | Editor | `F6` | Reader mode |
+| Editor | `F7` | Toggle spell check |
 | Writing | `Ctrl+z` | Undo |
 | Writing | `Ctrl+y` | Redo |
 | Writing | `Ctrl+x` | Cut |

--- a/prosaic/screens/editor.py
+++ b/prosaic/screens/editor.py
@@ -32,6 +32,7 @@ class EditorScreen(Screen, inherit_bindings=False):
         Binding("ctrl+o", "toggle_outline", "outline"),
         Binding("f5", "toggle_focus", "focus mode"),
         Binding("f6", "toggle_reader", "reader mode"),
+        Binding("f7", "toggle_spell", "spell check"),
         Binding("f1", "show_help", "help"),
     ]
 
@@ -316,6 +317,18 @@ class EditorScreen(Screen, inherit_bindings=False):
             self.reader_mode = True
             self.focus_mode = False
             self.notify("Reader mode on")
+
+    def action_toggle_spell(self) -> None:
+        editor = self.query_one("#editor", SpellCheckTextArea)
+        editor.spell_check_enabled = not editor.spell_check_enabled
+        try:
+            statusbar = self.query_one("#statusbar", StatusBar)
+            statusbar.spell_check = editor.spell_check_enabled
+        except Exception:
+            pass
+        self.notify(
+            "Spell check on" if editor.spell_check_enabled else "Spell check off"
+        )
 
     def action_save(self) -> None:
         self._save_file()

--- a/prosaic/themes/dark.tcss
+++ b/prosaic/themes/dark.tcss
@@ -416,11 +416,13 @@ TextArea > .text-area--cursor-gutter {
 #statusbar > #modified {
     color: $warning;
     width: auto;
+    margin-left: 1;
 }
 
 #statusbar > #git {
     color: $secondary;
     width: auto;
+    margin-left: 1;
 }
 
 #statusbar > #autosave {

--- a/prosaic/themes/dark.tcss
+++ b/prosaic/themes/dark.tcss
@@ -429,6 +429,12 @@ TextArea > .text-area--cursor-gutter {
     margin-right: 1;
 }
 
+#statusbar > #spell {
+    color: $text-muted;
+    width: auto;
+    margin-left: 1;
+}
+
 .spacer {
     width: 1fr;
 }

--- a/prosaic/themes/light.tcss
+++ b/prosaic/themes/light.tcss
@@ -416,11 +416,13 @@ TextArea > .text-area--cursor-gutter {
 #statusbar > #modified {
     color: $warning;
     width: auto;
+    margin-left: 1;
 }
 
 #statusbar > #git {
     color: $secondary;
     width: auto;
+    margin-left: 1;
 }
 
 #statusbar > #autosave {

--- a/prosaic/themes/light.tcss
+++ b/prosaic/themes/light.tcss
@@ -429,6 +429,12 @@ TextArea > .text-area--cursor-gutter {
     margin-right: 1;
 }
 
+#statusbar > #spell {
+    color: $text-muted;
+    width: auto;
+    margin-left: 1;
+}
+
 .spacer {
     width: 1fr;
 }

--- a/prosaic/widgets/spell_text_area.py
+++ b/prosaic/widgets/spell_text_area.py
@@ -5,6 +5,7 @@ import re
 from rich.style import Style
 from spellchecker import SpellChecker
 from textual.binding import Binding
+from textual.reactive import reactive
 from textual.widgets import TextArea
 from textual.widgets.text_area import TextAreaTheme
 
@@ -81,6 +82,8 @@ _INLINE_CODE = re.compile(r"(`)([^`]+)(`)")
 
 class SpellCheckTextArea(TextArea, inherit_bindings=False):
     """TextArea with live spell-check underlines and markdown highlighting."""
+
+    spell_check_enabled: reactive[bool] = reactive(True)
 
     BINDINGS = [
         Binding("ctrl+a", "select_all", "select all"),
@@ -183,6 +186,8 @@ class SpellCheckTextArea(TextArea, inherit_bindings=False):
 
     def _scan_spelling(self, text: str) -> None:
         self._misspelled.clear()
+        if not self.spell_check_enabled:
+            return
         in_frontmatter = False
         in_code_block = False
 
@@ -236,6 +241,13 @@ class SpellCheckTextArea(TextArea, inherit_bindings=False):
                 self._highlights[row] = []
             for col_s, col_e, style in highlights:
                 self._highlights[row].append((col_s, col_e, style))
+
+    def watch_spell_check_enabled(self, enabled: bool) -> None:
+        self._build_highlight_map()
+        self.refresh()
+
+    def action_toggle_spell_check(self) -> None:
+        self.spell_check_enabled = not self.spell_check_enabled
 
     def action_toggle_comment(self) -> None:
         """Toggle markdown comment on current line."""

--- a/prosaic/widgets/statusbar.py
+++ b/prosaic/widgets/statusbar.py
@@ -68,7 +68,7 @@ class StatusBar(Horizontal):
         yield Static("untitled", id="filename")
         yield Static("", id="modified")
         yield Static("", id="git")
-        yield Static("spell:on", id="spell")
+        yield Static("spellcheck:on", id="spell")
         yield Static("", classes="spacer")
         yield Static("0 words", id="word-count")
         yield Static("·", classes="sep")
@@ -81,15 +81,15 @@ class StatusBar(Horizontal):
         try:
             self.query_one("#filename", Static).update(self.filename)
             self.query_one("#modified", Static).update(
-                " [+]" if self.modified else " [·]"
+                "[+]" if self.modified else "[·]"
             )
-            self.query_one("#git", Static).update(
-                f"  {self.git_status}" if self.git_status else ""
-            )
+            git = self.query_one("#git", Static)
+            git.update(self.git_status)
+            git.display = bool(self.git_status)
             self.query_one("#word-count", Static).update(f"{self.words:,} words")
             self.query_one("#char-count", Static).update(f"{self.characters:,} chars")
             self.query_one("#spell", Static).update(
-                "spell:on" if self.spell_check else "spell:off"
+                "spellcheck:on" if self.spell_check else "spellcheck:off"
             )
         except Exception:
             pass
@@ -102,13 +102,15 @@ class StatusBar(Horizontal):
 
     def watch_modified(self, modified: bool) -> None:
         try:
-            self.query_one("#modified", Static).update(" [+]" if modified else " [·]")
+            self.query_one("#modified", Static).update("[+]" if modified else "[·]")
         except Exception:
             pass
 
     def watch_git_status(self, status: str) -> None:
         try:
-            self.query_one("#git", Static).update(f"  {status}" if status else "")
+            git = self.query_one("#git", Static)
+            git.update(status)
+            git.display = bool(status)
         except Exception:
             pass
 
@@ -127,7 +129,7 @@ class StatusBar(Horizontal):
     def watch_spell_check(self, enabled: bool) -> None:
         try:
             self.query_one("#spell", Static).update(
-                "spell:on" if enabled else "spell:off"
+                "spellcheck:on" if enabled else "spellcheck:off"
             )
         except Exception:
             pass

--- a/prosaic/widgets/statusbar.py
+++ b/prosaic/widgets/statusbar.py
@@ -61,12 +61,14 @@ class StatusBar(Horizontal):
     characters: reactive[int] = reactive(0)
     modified: reactive[bool] = reactive(False)
     git_status: reactive[str] = reactive("")
+    spell_check: reactive[bool] = reactive(True)
 
     def compose(self):
         yield Static("○", id="autosave")
         yield Static("untitled", id="filename")
         yield Static("", id="modified")
         yield Static("", id="git")
+        yield Static("spell:on", id="spell")
         yield Static("", classes="spacer")
         yield Static("0 words", id="word-count")
         yield Static("·", classes="sep")
@@ -86,6 +88,9 @@ class StatusBar(Horizontal):
             )
             self.query_one("#word-count", Static).update(f"{self.words:,} words")
             self.query_one("#char-count", Static).update(f"{self.characters:,} chars")
+            self.query_one("#spell", Static).update(
+                "spell:on" if self.spell_check else "spell:off"
+            )
         except Exception:
             pass
 
@@ -116,6 +121,14 @@ class StatusBar(Horizontal):
     def watch_characters(self, chars: int) -> None:
         try:
             self.query_one("#char-count", Static).update(f"{chars:,} chars")
+        except Exception:
+            pass
+
+    def watch_spell_check(self, enabled: bool) -> None:
+        try:
+            self.query_one("#spell", Static).update(
+                "spell:on" if enabled else "spell:off"
+            )
         except Exception:
             pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prosaic-app"
-version = "1.4.4"
+version = "1.4.5"
 description = "A writer-first terminal writing app"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Adds an `F7` keybinding in the editor that toggles the spell-checker on and off for the current session.
- Adds a `spell:on` / `spell:off` indicator to the status bar so the current state is always visible (hidden together with the rest of the bar in focus mode).
- Default behavior is unchanged: every new session starts with spell-check on. The toggle is intentionally **not persisted** in this PR.

## Why

Refs #4. The spell-checker is hard-coded to English (`SpellChecker()` with no language argument), so writers using the editor in another language (Hungarian, Italian, …) currently get every word underlined as a misspelling and there is no way to silence it without restarting or editing the source.

This PR is meant as a small, low-risk first step: give people a way to turn the noise off **today**, while a proper multi-language / per-profile language solution is being designed. It does not close #4 on purpose — full language configuration is the follow-up.

## Implementation notes

- `prosaic/widgets/spell_text_area.py`: new `spell_check_enabled: reactive[bool]` on `SpellCheckTextArea`. `_scan_spelling` early-returns when the flag is off, and `watch_spell_check_enabled` rebuilds the highlight map + refreshes so the underlines disappear immediately on toggle. Markdown highlighting is not affected.
- `prosaic/screens/editor.py`: new `Binding("f7", "toggle_spell", "spell check")` and an `action_toggle_spell` that flips the flag on the editor, mirrors the value to the status bar, and shows a toast (same UX as `F5`/`F6`).
- `prosaic/widgets/statusbar.py`: new `spell_check: reactive[bool]` plus a `#spell` `Static` slot rendered as `spell:on` / `spell:off`. Follows the same `reactive` + `watch_*` pattern already used by `filename`, `modified`, `git_status`, etc.
- `prosaic/themes/light.tcss` / `prosaic/themes/dark.tcss`: a small style rule for `#spell` (muted color, `width: auto`, left margin) consistent with the rest of the status bar.
- `README.md`: an `F7` row added to the keybindings table.

No new dependencies. No config changes. No `settings.json` changes.

## Test plan

- [x] Launch the editor on a fresh session → status bar shows `spell:on`.
- [x] Type non-English text (e.g. `Questo è un test in italiano`) → words are underlined red.
- [x] Press `F7` → underlines disappear immediately, toast says `Spell check off`, indicator becomes `spell:off`.
- [x] Continue typing while off → no new underlines appear.
- [x] Press `F7` again → underlines come back, indicator returns to `spell:on`.
- [x] Enter focus mode (`F5`) → status bar (and indicator) hidden; exit focus mode → indicator returns in the correct state.
- [x] Open a different file from the file tree → toggle state is preserved within the session.
- [x] Quit and relaunch the app → spell-check is back to `on` (no persistence, by design).

## Out of scope (follow-ups)

- Persisting the toggle in `settings.json` / per profile.
- Supporting non-English dictionaries (Italian, Hungarian, …) and language switching.
- A user-managed custom-words dictionary.
- Grammar checking (the optional `language-tool-python` extra in `pyproject.toml`).