### PR TITLE
feat: add customisable spellcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-04-27
+
+### Added
+
+- Spell check now supports 80+ languages powered by hunspell, including Hungarian, Arabic, Polish, French, and many more. Language is set per profile during setup and can be changed any time in manage profiles.
+- Spell check language selection is part of the setup wizard and the new profile flow.
+- Existing users are prompted to set a language on first launch after upgrading, with the option to configure each profile individually.
+- `--languages` flag lists all supported language codes with names.
+- Spellcheck settings persist per profile.
+- Spell check on/off toggle added to edit and new profile modals (`ctrl+k`).
+- SPELL CHECK section added to `--reference`.
+
 ## [1.4.5] - 2026-04-27
 
 ### Added

--- a/landing/documentation.html
+++ b/landing/documentation.html
@@ -46,8 +46,8 @@
                             <span class="docs-desc">Run setup wizard again</span>
                         </div>
                         <div class="docs-row">
-                            <span class="docs-option">--reference</span>
-                            <span class="docs-desc">Show reference</span>
+                            <span class="docs-option">--reference / --languages </span>
+                            <span class="docs-desc">Show reference or list valid languages</span>
                         </div>
                         <div class="docs-row">
                             <span class="docs-option">--license</span>

--- a/prosaic/REFERENCE
+++ b/prosaic/REFERENCE
@@ -83,6 +83,19 @@ Each profile has its own archive, git remote, and theme.
 Manage from dashboard (m key) or edit settings.json.
 
 
+SPELL CHECK
+-----------
+
+Spell check is powered by hunspell and supports 80+ languages.
+Each profile has its own language setting.
+
+  F7                          Toggle spell check on/off
+  prosaic --languages         List all supported language codes
+
+Language is set per profile during setup or via manage profiles (m).
+Misspelled words are underlined in the editor.
+
+
 PANE DEFAULTS
 -------------
 

--- a/prosaic/VALID_LANGUAGES
+++ b/prosaic/VALID_LANGUAGES
@@ -1,0 +1,78 @@
+af_ZA	Afrikaans
+an_ES	Aragonese
+ar	Arabic
+be_BY	Belarusian
+bg_BG	Bulgarian
+br_FR	Breton
+ca_ES	Catalan
+cs_CZ	Czech
+da_DK	Danish
+de_AT	German (Austria)
+de_CH	German (Switzerland)
+de_DE	German (Germany)
+el_GR	Greek
+en_AU	English (Australian)
+en_CA	English (Canada)
+en_GB	English (Great Britain)
+en_US	English (US)
+en_ZA	English (South African)
+es	Spanish (all variants)
+es_AR	Spanish (Argentina)
+es_BO	Spanish (Bolivia)
+es_CL	Spanish (Chile)
+es_CO	Spanish (Colombia)
+es_CR	Spanish (Costa Rica)
+es_CU	Spanish (Cuba)
+es_DO	Spanish (Dominican Republic)
+es_EC	Spanish (Ecuador)
+es_ES	Spanish (Spain)
+es_GQ	Spanish (Equatorial Guinea)
+es_GT	Spanish (Guatemala)
+es_HN	Spanish (Honduras)
+es_MX	Spanish (Mexico)
+es_NI	Spanish (Nicaragua)
+es_PA	Spanish (Panama)
+es_PE	Spanish (Peru)
+es_PH	Spanish (Philippines)
+es_PR	Spanish (Puerto Rico)
+es_PY	Spanish (Paraguay)
+es_SV	Spanish (El Salvador)
+es_US	Spanish (US)
+es_UY	Spanish (Uruguay)
+es_VE	Spanish (Venezuela)
+et_EE	Estonian
+fr_FR	French
+gd_GB	Scottish Gaelic
+gu_IN	Gujarati
+gug_PY	Guarani
+he_IL	Hebrew
+hi_IN	Hindi
+hr_HR	Croatian
+hu_HU	Hungarian
+id_ID	Indonesian
+is	Icelandic
+it_IT	Italian
+ku_TR	Kurdish (Turkey)
+lt_LT	Lithuanian
+lv_LV	Latvian
+md	Mapudungun
+nb_NO	Norwegian (Bokmal)
+nl_NL	Dutch (Netherlands)
+nn_NO	Norwegian (Nynorsk)
+oc_FR	Occitan
+pl_PL	Polish
+pt_BR	Portuguese (Brazilian)
+pt_PT	Portuguese
+ro_RO	Romanian
+si_LK	Sinhala
+sk_SK	Slovak
+sl_SI	Slovenian
+sr	Serbian (Cyrillic)
+sr-Latn	Serbian (Latin)
+sv_SE	Swedish
+sw_TZ	Swahili
+ta	Tamil
+th_TH	Thai
+tr_TR	Turkish
+uk_UA	Ukrainian
+vi_VN	Vietnamese

--- a/prosaic/__main__.py
+++ b/prosaic/__main__.py
@@ -8,19 +8,25 @@ from textual.binding import Binding
 from textual.screen import ModalScreen
 
 from prosaic.config import (
+    LANGUAGE_NAMES,
+    VALID_LANGUAGE_CODES,
     ensure_workspace,
     get_active_profile,
     get_app_version,
     get_notes_path,
     get_profile_config,
     get_workspace_dir,
-    list_profiles,
     load_config,
+    needs_language_setup,
+    profiles_needing_language_setup,
     save_config,
+    save_profile_config,
     set_active_profile,
     set_last_file,
+    set_spell_check_enabled,
     was_just_migrated,
 )
+
 from prosaic.core.metrics import MetricsTracker
 from prosaic.screens import DashboardScreen, EditorScreen
 from prosaic.themes import PROSAIC_DARK_CSS, PROSAIC_LIGHT_CSS
@@ -45,6 +51,66 @@ def _get_license_text() -> str:
     """Read LICENSE file from package."""
     content = read_text(Path(__file__).parent / "LICENSE")
     return _wrap_output(content)
+
+
+def _run_spell_setup(profile_name: str) -> None:
+    """Run the one-time spell check setup for existing users upgrading to 1.5.0."""
+    current_version = get_app_version()
+    click.echo()
+    click.secho(f"welcome to prosaic {current_version}!", fg="yellow", bold=True)
+    click.echo(
+        "this version brings a more powerful spell check with support for"
+        " 80+ languages powered by hunspell."
+    )
+    click.echo()
+
+    enable = click.confirm("enable spell check?", default=True)
+    set_spell_check_enabled(enable, profile_name)
+
+    if not enable:
+        return
+
+    click.echo()
+    for code in sorted(VALID_LANGUAGE_CODES):
+        name = LANGUAGE_NAMES.get(code, "")
+        click.echo(f"  {code:<10}  {name}")
+    click.echo()
+    click.echo("you can also view this later with:  prosaic --languages")
+    click.echo()
+    lang = click.prompt(
+        f"language for '{profile_name}'",
+        default="en_US",
+        show_default=True,
+    ).strip()
+    if lang not in VALID_LANGUAGE_CODES:
+        click.secho(f"unknown language code '{lang}' — defaulting to en_US", fg="yellow")
+        lang = "en_US"
+    else:
+        click.secho(f"  {LANGUAGE_NAMES.get(lang, lang)}", fg="green")
+
+    data = get_profile_config(profile_name)
+    data["spell_language"] = lang
+    save_profile_config(data, profile_name)
+
+    others = [p for p in profiles_needing_language_setup() if p != profile_name]
+    if others:
+        click.echo()
+        if click.confirm(f"configure other profiles now? ({', '.join(others)})", default=False):
+            for other in others:
+                click.echo()
+                other_lang = click.prompt(
+                    f"language for '{other}'",
+                    default="en_US",
+                    show_default=True,
+                ).strip()
+                if other_lang not in VALID_LANGUAGE_CODES:
+                    click.secho(f"  unknown code '{other_lang}' — defaulting to en_US", fg="yellow")
+                    other_lang = "en_US"
+                else:
+                    click.secho(f"  {LANGUAGE_NAMES.get(other_lang, other_lang)}", fg="green")
+                other_data = get_profile_config(other)
+                other_data["spell_language"] = other_lang
+                save_profile_config(other_data, other)
 
 
 class ProsaicApp(App):
@@ -178,6 +244,7 @@ class ProsaicApp(App):
 @click.option("--setup", is_flag=True, help="Run setup wizard again")
 @click.option("--profile", default=None, help="Use a named profile (see --profiles)")
 @click.option("--profiles", "show_profiles", is_flag=True, help="List available profiles")
+@click.option("--languages", "show_languages", is_flag=True, help="List valid spell check language codes")
 @click.option("--reference", is_flag=True, help="Show reference")
 @click.option("--license", "show_license", is_flag=True, help="Show MIT license")
 @click.argument("file", required=False, type=click.Path())
@@ -186,6 +253,7 @@ def main(
     setup: bool,
     profile: str | None,
     show_profiles: bool,
+    show_languages: bool,
     reference: bool,
     show_license: bool,
     file: str | None,
@@ -206,6 +274,16 @@ def main(
             click.echo("no profiles configured. run: prosaic --setup")
         return
 
+    if show_languages:
+        click.echo("valid spell check language codes:")
+        click.echo()
+        for code in sorted(VALID_LANGUAGE_CODES):
+            name = LANGUAGE_NAMES.get(code, "")
+            click.echo(f"  {code:<10}  {name}")
+        click.echo()
+        click.echo("set language in manage profiles (m) or via  prosaic --profile <name>")
+        return
+
     if reference:
         click.echo(_get_reference_text())
         return
@@ -223,16 +301,16 @@ def main(
 
     if is_legacy_upgrade and not setup:
         click.echo()
-        click.secho(f"new in prosaic {current_version}!", fg="yellow", bold=True)
+        click.secho(f"hello from prosaic {current_version}!", fg="yellow", bold=True)
         click.echo()
-        click.echo("this version introduces profiles - separate workspaces for")
+        click.echo("looks like you just upgraded. we've automatically migrated")
+        click.echo("your config to the new format and taken a backup just in case.")
+        click.echo()
+        click.echo("this version introduces profiles — separate workspaces for")
         click.echo("different writing projects (personal, work, fiction, etc.)")
-        click.echo()
         click.echo("your existing setup has been preserved as the 'default' profile.")
         click.echo()
-
-        click.echo("would you like to learn about profiles and set up more now?")
-        click.echo("you can always do it later with prosaic --setup")
+        click.echo("you can always run  prosaic --setup  to configure more.")
         click.echo()
         run_profiles_setup = click.confirm("set up profiles now?", default=False)
 
@@ -272,10 +350,14 @@ def main(
                 setup_workspace(profile_data)
 
         set_active_profile(result["active_profile"])
+        profile_name = result["active_profile"]
 
     if config.get("app_version") != current_version:
         config["app_version"] = current_version
         save_config(config)
+
+    if needs_language_setup(profile_name):
+        _run_spell_setup(profile_name)
 
     if light is None:
         profile_config = get_profile_config(get_active_profile())

--- a/prosaic/config.py
+++ b/prosaic/config.py
@@ -15,6 +15,34 @@ except ImportError:
 
 _active_profile: str = "default"
 _just_migrated: bool = False
+_runtime_config: dict | None = None
+
+def _load_valid_languages() -> tuple[frozenset[str], dict[str, str]]:
+    path = Path(__file__).parent / "VALID_LANGUAGES"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        codes = {}
+        for line in lines:
+            parts = line.split("\t", 1)
+            if len(parts) == 2:
+                codes[parts[0].strip()] = parts[1].strip()
+        return frozenset(codes.keys()), codes
+    except OSError:
+        return frozenset({"en_US", "en_GB"}), {"en_US": "English (US)", "en_GB": "English (Great Britain)"}
+
+VALID_LANGUAGE_CODES, LANGUAGE_NAMES = _load_valid_languages()
+
+
+def get_spell_check_enabled(profile_name: str | None = None) -> bool:
+    """Return whether spell check is enabled for a profile."""
+    return get_profile_config(profile_name).get("spell_check_enabled", True)
+
+
+def set_spell_check_enabled(enabled: bool, profile_name: str | None = None) -> None:
+    """Persist spell check enabled state for a profile."""
+    profile = get_profile_config(profile_name)
+    profile["spell_check_enabled"] = enabled
+    save_profile_config(profile, profile_name)
 
 
 def get_active_profile() -> str:
@@ -123,8 +151,16 @@ def migrate_config(config: dict) -> dict:
 def load_config() -> dict:
     """Load configuration from settings.json.
 
-    Automatically migrates legacy configs to v2 format.
+    Migrates legacy configs to v2 format in memory. The migrated config is
+    cached and only written to disk when save_config() is called explicitly
+    (after setup completes), so the user's original file is never overwritten
+    until they finish setup.
     """
+    global _runtime_config, _just_migrated
+
+    if _runtime_config is not None:
+        return _runtime_config
+
     config_path = get_config_path()
     if not config_path.exists():
         return {}
@@ -135,20 +171,21 @@ def load_config() -> dict:
         return {}
 
     if "app_version" not in config and config.get("setup_complete"):
-        global _just_migrated
         _just_migrated = True
         backup_config()
         config = migrate_config(config)
-        save_config(config)
+        _runtime_config = config  # cache in memory; main() saves after setup
 
     return config
 
 
 def save_config(config: dict) -> None:
     """Save configuration to settings.json."""
+    global _runtime_config
     config_path = get_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
     write_text(config_path, json.dumps(config, indent=2))
+    _runtime_config = None  # clear cache; disk is now authoritative
 
 
 def get_profile_config(profile_name: str | None = None) -> dict:
@@ -304,6 +341,16 @@ def set_last_file(path: Path) -> None:
     profile = get_profile_config()
     profile["last_file"] = str(path)
     save_profile_config(profile)
+
+
+def needs_language_setup(profile_name: str | None = None) -> bool:
+    """Return True if this profile has no spell_language set yet."""
+    return "spell_language" not in get_profile_config(profile_name)
+
+
+def profiles_needing_language_setup() -> list[str]:
+    """Return all profile names that have no spell_language set."""
+    return [p for p in list_profiles() if needs_language_setup(p)]
 
 
 def ensure_workspace() -> None:

--- a/prosaic/screens/editor.py
+++ b/prosaic/screens/editor.py
@@ -12,7 +12,7 @@ from textual.screen import Screen
 from textual.widgets import Static, TextArea
 
 from prosaic.app import HelpScreen
-from prosaic.config import get_books_dir, get_workspace_dir
+from prosaic.config import get_books_dir, get_profile_config, get_workspace_dir, get_spell_check_enabled, set_spell_check_enabled
 from prosaic.core import count_characters, count_words
 from prosaic.core.metrics import MetricsTracker
 from prosaic.utils import read_text, write_text
@@ -67,6 +67,8 @@ class EditorScreen(Screen, inherit_bindings=False):
 
     def compose(self) -> ComposeResult:
         ta_theme = "prosaic_light" if self._light_mode else "prosaic_dark"
+        profile = get_profile_config()
+        spell_lang = profile.get("spell_language", "en")
         with Horizontal(id="editor-layout"):
             yield FileTree(get_workspace_dir(), id="file-tree")
             with Vertical(id="editor-container"):
@@ -75,6 +77,7 @@ class EditorScreen(Screen, inherit_bindings=False):
                     language="markdown",
                     soft_wrap=True,
                     theme=ta_theme,
+                    spell_language=spell_lang,
                 )
             outline = OutlinePanel(id="outline")
             outline.display = False
@@ -82,9 +85,17 @@ class EditorScreen(Screen, inherit_bindings=False):
         yield StatusBar(id="statusbar")
 
     def on_mount(self) -> None:
-        editor = self.query_one("#editor", TextArea)
+        editor = self.query_one("#editor", SpellCheckTextArea)
         editor.focus()
         self.set_interval(10, self._autosave)
+
+        spell_enabled = get_spell_check_enabled()
+        editor.spell_check_enabled = spell_enabled
+        try:
+            statusbar = self.query_one("#statusbar", StatusBar)
+            statusbar.spell_check = spell_enabled
+        except Exception:
+            pass
 
         if self._initial_file and self._initial_file.exists():
             self._load_file(self._initial_file)
@@ -321,6 +332,7 @@ class EditorScreen(Screen, inherit_bindings=False):
     def action_toggle_spell(self) -> None:
         editor = self.query_one("#editor", SpellCheckTextArea)
         editor.spell_check_enabled = not editor.spell_check_enabled
+        set_spell_check_enabled(editor.spell_check_enabled)
         try:
             statusbar = self.query_one("#statusbar", StatusBar)
             statusbar.spell_check = editor.spell_check_enabled

--- a/prosaic/screens/profiles.py
+++ b/prosaic/screens/profiles.py
@@ -9,6 +9,7 @@ from textual.screen import ModalScreen, Screen
 from textual.widgets import Input, Static
 
 from prosaic.config import (
+    VALID_LANGUAGE_CODES,
     delete_profile,
     get_active_profile,
     list_profiles,
@@ -17,7 +18,12 @@ from prosaic.config import (
     rename_profile,
     save_config,
     save_profile_config,
+    get_spell_check_enabled,
 )
+
+
+def _validated_language(lang: str) -> str:
+    return lang if lang in VALID_LANGUAGE_CODES else "en_US"
 
 
 class EditProfileModal(ModalScreen[bool]):
@@ -27,6 +33,7 @@ class EditProfileModal(ModalScreen[bool]):
         Binding("escape", "cancel", "cancel"),
         Binding("ctrl+t", "toggle_theme", "toggle theme", priority=True),
         Binding("ctrl+d", "toggle_default", "toggle default", priority=True),
+        Binding("ctrl+k", "toggle_spell_check", "toggle spell check", priority=True),
     ]
 
     def __init__(self, profile_name: str, **kwargs) -> None:
@@ -34,6 +41,7 @@ class EditProfileModal(ModalScreen[bool]):
         self.profile_name = profile_name
         self.profile_config = get_profile_config(profile_name)
         self._theme = self.profile_config.get("theme", "light")
+        self._spell_check_enabled = self.profile_config.get("spell_check_enabled", True)
         config = load_config()
         self._is_default = config.get("active_profile") == profile_name
 
@@ -61,10 +69,20 @@ class EditProfileModal(ModalScreen[bool]):
                 id="git-remote-input",
             )
 
+            yield Static("spell language (e.g. en_US, hu_HU, fr_FR):")
+            yield Input(
+                value=self.profile_config.get("spell_language", "en_US"),
+                max_length=20,
+                id="language-input",
+            )
+            yield Static("", id="language-error", classes="dialog-hint")
+
             yield Static(f"theme: {self._theme}  (ctrl+t) toggle", id="theme-display")
             default_marker = "yes" if self._is_default else "no"
             yield Static(f"default: {default_marker}  (ctrl+d) toggle", id="default-display")
-            yield Static("(theme changes require restart)", classes="dialog-hint")
+            spell_marker = "on" if self._spell_check_enabled else "off"
+            yield Static(f"spell check: {spell_marker}  (ctrl+k) toggle", id="spell-check-display")
+            yield Static("(theme/language changes require restart)", classes="dialog-hint")
 
             yield Static("(enter) save  (esc) cancel", classes="dialog-hint")
 
@@ -74,6 +92,11 @@ class EditProfileModal(ModalScreen[bool]):
     def action_toggle_theme(self) -> None:
         self._theme = "dark" if self._theme == "light" else "light"
         self.query_one("#theme-display", Static).update(f"theme: {self._theme}  (ctrl+t) toggle")
+
+    def action_toggle_spell_check(self) -> None:
+        self._spell_check_enabled = not self._spell_check_enabled
+        marker = "on" if self._spell_check_enabled else "off"
+        self.query_one("#spell-check-display", Static).update(f"spell check: {marker}  (ctrl+k) toggle")
 
     def action_toggle_default(self) -> None:
         self._is_default = not self._is_default
@@ -87,9 +110,16 @@ class EditProfileModal(ModalScreen[bool]):
         new_name = self.query_one("#profile-name-input", Input).value.strip().lower()
         new_workspace = self.query_one("#workspace-input", Input).value.strip()
         git_remote = self.query_one("#git-remote-input", Input).value.strip()
+        raw_lang = self.query_one("#language-input", Input).value.strip()
 
         if not new_name or not new_workspace:
             return
+
+        lang = _validated_language(raw_lang)
+        if lang != raw_lang:
+            self.query_one("#language-error", Static).update(
+                f"unknown language '{raw_lang}' — defaulting to en_US"
+            )
 
         workspace_path = Path(new_workspace).expanduser().resolve()
 
@@ -102,6 +132,8 @@ class EditProfileModal(ModalScreen[bool]):
         profile["archive_dir"] = str(workspace_path)
         profile["git_remote"] = git_remote
         profile["theme"] = self._theme
+        profile["spell_language"] = lang
+        profile["spell_check_enabled"] = self._spell_check_enabled
         if "init_git" not in profile:
             profile["init_git"] = True
         save_profile_config(profile, target_name)
@@ -123,11 +155,13 @@ class NewProfileModal(ModalScreen[str | None]):
     BINDINGS = [
         Binding("escape", "cancel", "cancel"),
         Binding("ctrl+t", "toggle_theme", "toggle theme", priority=True),
+        Binding("ctrl+k", "toggle_spell_check", "toggle spell check", priority=True),
     ]
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._theme = "light"
+        self._spell_check_enabled = True
 
     def compose(self) -> ComposeResult:
         with Vertical(id="dialog"):
@@ -152,6 +186,17 @@ class NewProfileModal(ModalScreen[str | None]):
             )
 
             yield Static(f"theme: {self._theme}  (ctrl+t) toggle", id="theme-display")
+            spell_marker = "on" if self._spell_check_enabled else "off"
+            yield Static(f"spell check: {spell_marker}  (ctrl+k) toggle", id="spell-check-display")
+
+            yield Static("spell language (e.g. en_US, hu_HU, fr_FR):")
+            yield Input(
+                value="en_US",
+                placeholder="en_US",
+                max_length=20,
+                id="language-input",
+            )
+            yield Static("", id="language-error", classes="dialog-hint")
 
             yield Static("(enter) create  (esc) cancel", classes="dialog-hint")
 
@@ -162,6 +207,11 @@ class NewProfileModal(ModalScreen[str | None]):
         self._theme = "dark" if self._theme == "light" else "light"
         self.query_one("#theme-display", Static).update(f"theme: {self._theme}  (ctrl+t) toggle")
 
+    def action_toggle_spell_check(self) -> None:
+        self._spell_check_enabled = not self._spell_check_enabled
+        marker = "on" if self._spell_check_enabled else "off"
+        self.query_one("#spell-check-display", Static).update(f"spell check: {marker}  (ctrl+k) toggle")
+
     def on_input_submitted(self, event: Input.Submitted) -> None:
         self._create_profile()
 
@@ -169,12 +219,19 @@ class NewProfileModal(ModalScreen[str | None]):
         name = self.query_one("#profile-name-input", Input).value.strip().lower()
         workspace = self.query_one("#workspace-input", Input).value.strip()
         git_remote = self.query_one("#git-remote-input", Input).value.strip()
+        raw_lang = self.query_one("#language-input", Input).value.strip()
 
         if not name or not workspace:
             return
 
         if name in list_profiles():
             return
+
+        lang = _validated_language(raw_lang)
+        if lang != raw_lang:
+            self.query_one("#language-error", Static).update(
+                f"unknown language '{raw_lang}' — defaulting to en_US"
+            )
 
         workspace_path = Path(workspace).expanduser().resolve()
 
@@ -183,6 +240,8 @@ class NewProfileModal(ModalScreen[str | None]):
             "init_git": True,
             "git_remote": git_remote,
             "theme": self._theme,
+            "spell_language": lang,
+            "spell_check_enabled": self._spell_check_enabled,
         }
         save_profile_config(profile_data, name)
 
@@ -256,6 +315,10 @@ class ProfilesScreen(Screen):
                 else:
                     yield Static(f"  git: {'yes' if git_enabled else 'no'}", classes="profile-detail")
                 yield Static(f"  theme: {theme_name}", classes="profile-detail")
+                spell_lang = config.get("spell_language", "en_US")
+                spell_enabled = config.get("spell_check_enabled", True)
+                yield Static(f"  language: {spell_lang}", classes="profile-detail")
+                yield Static(f"  spell check: {'on' if spell_enabled else 'off'}", classes="profile-detail")
 
                 if other_profiles:
                     yield Static("", classes="profile-spacer")

--- a/prosaic/widgets/spell_text_area.py
+++ b/prosaic/widgets/spell_text_area.py
@@ -3,9 +3,10 @@
 import re
 
 from rich.style import Style
-from spellchecker import SpellChecker
 from textual.binding import Binding
 from textual.reactive import reactive
+
+from phunspell import Phunspell
 from textual.widgets import TextArea
 from textual.widgets.text_area import TextAreaTheme
 
@@ -69,7 +70,7 @@ PROSAIC_DARK_TA = TextAreaTheme(
 )
 
 _SKIP_LINE = re.compile(r"^(#{1,6}\s|```|---|\s*[-*+]\s|\s*\d+\.\s|>\s|!\[)")
-_WORD = re.compile(r"\b([a-zA-Z']{3,})\b")
+_WORD = re.compile(r"\b([^\W\d_]{3,})\b", re.UNICODE)
 _SPELL_STYLE = Style(underline=True, color="#c24038")
 
 _BOLD_ASTERISK = re.compile(r"(\*\*)([^*]+)(\*\*)")
@@ -121,8 +122,9 @@ class SpellCheckTextArea(TextArea, inherit_bindings=False):
         Binding("ctrl+y", "redo", "redo", show=False),
     ]
 
-    def __init__(self, *args, **kwargs) -> None:
-        self._spell: SpellChecker = SpellChecker()
+    def __init__(self, *args, spell_language: str = "en", **kwargs) -> None:
+        self._spell_language = spell_language
+        self._spell = self._init_spell(spell_language)
         self._misspelled: dict[int, list[tuple[int, int]]] = {}
         self._md_highlights: dict[int, list[tuple[int, int, str]]] = {}
         requested_theme = kwargs.pop("theme", "prosaic_light")
@@ -130,6 +132,12 @@ class SpellCheckTextArea(TextArea, inherit_bindings=False):
         self.register_theme(PROSAIC_LIGHT_TA)
         self.register_theme(PROSAIC_DARK_TA)
         self.theme = requested_theme
+
+    def _init_spell(self, language: str):
+        try:
+            return Phunspell(language)
+        except Exception:
+            return None
 
     def _scan_inline_markdown(self, text: str) -> None:
         """Scan for inline markdown elements (bold, italic, code)."""
@@ -211,10 +219,12 @@ class SpellCheckTextArea(TextArea, inherit_bindings=False):
             if not stripped or _SKIP_LINE.match(stripped):
                 continue
 
+            if self._spell is None:
+                continue
             spans: list[tuple[int, int]] = []
             for m in _WORD.finditer(line):
-                word = m.group(1).strip("'")
-                if self._spell.unknown([word]):
+                word = m.group(1)
+                if not self._spell.lookup(word):
                     spans.append((m.start(), m.end()))
             if spans:
                 self._misspelled[row] = spans

--- a/prosaic/wizard.py
+++ b/prosaic/wizard.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import click
 
-from prosaic.config import get_app_version, get_config_path, load_config
+from prosaic.config import get_app_version, get_config_path, load_config, VALID_LANGUAGE_CODES, LANGUAGE_NAMES
 from prosaic.utils import write_text
 
 try:
@@ -116,12 +116,31 @@ def _setup_single_profile(name: str) -> dict:
     use_light = click.confirm("use light theme as default?", default=True)
     theme = "light" if use_light else "dark"
 
+    click.echo()
+    spell_check_enabled = click.confirm("enable spell check?", default=True)
+    spell_language = "en_US"
+    if spell_check_enabled:
+        click.echo()
+        for code in sorted(VALID_LANGUAGE_CODES):
+            click.echo(f"  {code:<10}  {LANGUAGE_NAMES.get(code, '')}")
+        click.echo()
+        click.echo("you can also view this later with:  prosaic --languages")
+        click.echo()
+        raw = click.prompt("spell check language", default="en_US", show_default=True).strip()
+        if raw not in VALID_LANGUAGE_CODES:
+            click.secho(f"  unknown code '{raw}' — defaulting to en_US", fg="yellow")
+        else:
+            spell_language = raw
+            click.secho(f"  {LANGUAGE_NAMES.get(spell_language, spell_language)}", fg="green")
+
     return {
         "archive_dir": str(archive_path),
         "init_git": init_git,
         "git_remote": git_remote,
         "git_inherited": existing_git,
         "theme": theme,
+        "spell_check_enabled": spell_check_enabled,
+        "spell_language": spell_language,
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prosaic-app"
-version = "1.4.5"
+version = "1.5.0"
 description = "A writer-first terminal writing app"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
     "click>=8.1.0",
     "platformdirs>=4.0.0",
     "gitpython>=3.1.0",
-    "pyspellchecker>=0.8.0",
+    "phunspell>=0.1.6",
 ]
 
 [project.optional-dependencies]
@@ -53,7 +53,7 @@ where = ["."]
 exclude = ["build*", "tests*"]
 
 [tool.setuptools.package-data]
-prosaic = ["themes/*.tcss", "LICENSE", "REFERENCE"]
+prosaic = ["themes/*.tcss", "LICENSE", "REFERENCE", "VALID_LANGUAGES"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,15 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def clear_runtime_config_cache():
+    """Reset the in-memory config cache between tests."""
+    from prosaic import config as _config
+    _config._runtime_config = None
+    yield
+    _config._runtime_config = None
+
+
 @pytest.fixture
 def tmp_config_dir(tmp_path, monkeypatch):
     """Create a temporary config directory and patch get_config_dir."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -496,3 +496,87 @@ class TestUpdateProfileWorkspace:
         write_config(v2_config)
         result = config.update_profile_workspace("nonexistent", "/path")
         assert result is False
+
+
+class TestValidLanguageCodes:
+    """Tests for VALID_LANGUAGE_CODES constant."""
+
+    def test_contains_english(self):
+        assert "en_US" in config.VALID_LANGUAGE_CODES
+
+    def test_contains_hungarian(self):
+        assert "hu_HU" in config.VALID_LANGUAGE_CODES
+
+    def test_all_codes_are_strings(self):
+        for code in config.VALID_LANGUAGE_CODES:
+            assert isinstance(code, str)
+
+    def test_is_non_empty(self):
+        assert len(config.VALID_LANGUAGE_CODES) > 50
+
+
+class TestNeedsLanguageSetup:
+    """Tests for needs_language_setup()."""
+
+    def test_returns_true_when_missing(self, write_config, v2_config):
+        """Returns True when spell_language is absent from profile."""
+        write_config(v2_config)
+        assert config.needs_language_setup("default") is True
+
+    def test_returns_false_when_present(self, write_config, v2_config):
+        """Returns False when spell_language is set."""
+        v2_config["profiles"]["default"]["spell_language"] = "en"
+        write_config(v2_config)
+        assert config.needs_language_setup("default") is False
+
+    def test_uses_active_profile_when_none(self, write_config, v2_config):
+        """Uses active profile when profile_name is None."""
+        write_config(v2_config)
+        config.set_active_profile("default")
+        assert config.needs_language_setup(None) is True
+
+
+class TestProfilesNeedingLanguageSetup:
+    """Tests for profiles_needing_language_setup()."""
+
+    def test_returns_all_when_none_configured(self, write_config):
+        """Returns all profiles when none have spell_language."""
+        cfg = {
+            "app_version": "1.0.0",
+            "active_profile": "default",
+            "profiles": {
+                "default": {"archive_dir": "/a"},
+                "work": {"archive_dir": "/b"},
+            },
+        }
+        write_config(cfg)
+        result = config.profiles_needing_language_setup()
+        assert set(result) == {"default", "work"}
+
+    def test_excludes_configured_profiles(self, write_config):
+        """Excludes profiles that already have spell_language."""
+        cfg = {
+            "app_version": "1.0.0",
+            "active_profile": "default",
+            "profiles": {
+                "default": {"archive_dir": "/a", "spell_language": "en"},
+                "work": {"archive_dir": "/b"},
+            },
+        }
+        write_config(cfg)
+        result = config.profiles_needing_language_setup()
+        assert result == ["work"]
+
+    def test_returns_empty_when_all_configured(self, write_config):
+        """Returns empty list when all profiles have spell_language."""
+        cfg = {
+            "app_version": "1.0.0",
+            "active_profile": "default",
+            "profiles": {
+                "default": {"archive_dir": "/a", "spell_language": "en"},
+                "work": {"archive_dir": "/b", "spell_language": "hu"},
+            },
+        }
+        write_config(cfg)
+        result = config.profiles_needing_language_setup()
+        assert result == []

--- a/tests/test_spell.py
+++ b/tests/test_spell.py
@@ -1,0 +1,72 @@
+"""Tests for SpellCheckTextArea spell scanning behaviour."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from prosaic.widgets.spell_text_area import SpellCheckTextArea
+
+
+def _make_scan_target(spell_instance, enabled=True):
+    """Return a plain namespace that satisfies _scan_spelling's attribute reads."""
+    ns = SimpleNamespace(
+        _spell=spell_instance,
+        _misspelled={},
+        spell_check_enabled=enabled,
+    )
+    return ns
+
+
+class TestInitSpell:
+    def test_returns_none_when_phunspell_raises(self):
+        mock_phunspell = MagicMock(side_effect=Exception("bad language code"))
+        with patch("prosaic.widgets.spell_text_area.Phunspell", mock_phunspell):
+            ta = SpellCheckTextArea.__new__(SpellCheckTextArea)
+            result = ta._init_spell("xx_XX")
+            assert result is None
+
+    def test_returns_spell_instance_on_success(self):
+        mock_instance = MagicMock()
+        mock_phunspell = MagicMock(return_value=mock_instance)
+        with patch("prosaic.widgets.spell_text_area.Phunspell", mock_phunspell):
+            ta = SpellCheckTextArea.__new__(SpellCheckTextArea)
+            result = ta._init_spell("en_US")
+            assert result is mock_instance
+            mock_phunspell.assert_called_once_with("en_US")
+
+
+class TestScanSpelling:
+    def test_no_misspellings_when_spell_is_none(self):
+        ns = _make_scan_target(None)
+        SpellCheckTextArea._scan_spelling(ns, "hello wrold")
+        assert ns._misspelled == {}
+
+    def test_detects_misspelled_word(self):
+        mock_spell = MagicMock()
+        mock_spell.lookup.side_effect = lambda w: w == "hello"
+        ns = _make_scan_target(mock_spell)
+        SpellCheckTextArea._scan_spelling(ns, "hello wrold")
+        assert any(ns._misspelled.values())
+
+    def test_no_misspellings_for_correct_words(self):
+        mock_spell = MagicMock()
+        mock_spell.lookup.return_value = True
+        ns = _make_scan_target(mock_spell)
+        SpellCheckTextArea._scan_spelling(ns, "hello world")
+        assert ns._misspelled == {}
+
+    def test_skips_frontmatter(self):
+        mock_spell = MagicMock()
+        mock_spell.lookup.return_value = False
+        ns = _make_scan_target(mock_spell)
+        SpellCheckTextArea._scan_spelling(ns, "---\ntitle: wrold\n---\n\nhello")
+        misspelled_rows = list(ns._misspelled.keys())
+        assert 0 not in misspelled_rows
+        assert 1 not in misspelled_rows
+        assert 2 not in misspelled_rows
+
+    def test_no_scan_when_disabled(self):
+        mock_spell = MagicMock()
+        ns = _make_scan_target(mock_spell, enabled=False)
+        SpellCheckTextArea._scan_spelling(ns, "wrold")
+        assert ns._misspelled == {}
+        mock_spell.lookup.assert_not_called()

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -105,12 +105,9 @@ class TestRunSetupSingleProfile:
 
     def test_single_profile_mode(self, tmp_workspace):
         """Returns correct structure in single profile mode."""
-        inputs = [
-            str(tmp_workspace),  # archive directory
-            "n",  # init git
-        ]
-        with patch("click.prompt", side_effect=inputs):
-            with patch("click.confirm", return_value=False):
+        with patch("click.prompt", side_effect=[str(tmp_workspace), "en_US"]):
+            with patch("click.confirm", side_effect=[False, False, True]):
+                # 1. init git? no  2. light theme? no  3. enable spell check? yes
                 result = wizard.run_setup(
                     profile_name="work",
                     single_profile_mode=True,
@@ -120,6 +117,7 @@ class TestRunSetupSingleProfile:
         assert "work" in result["profiles"]
         assert result["active_profile"] == "work"
         assert result["profiles"]["work"]["archive_dir"] == str(tmp_workspace)
+        assert result["profiles"]["work"]["spell_language"] == "en_US"
 
 
 class TestRunSetupFresh:
@@ -128,26 +126,29 @@ class TestRunSetupFresh:
     def test_fresh_single_profile(self, tmp_workspace):
         """Fresh install with single profile (no multi-profile)."""
         with patch("click.prompt") as mock_prompt:
-            mock_prompt.side_effect = [str(tmp_workspace)]
+            mock_prompt.side_effect = [str(tmp_workspace), "en_US"]
             with patch("click.confirm") as mock_confirm:
-                # 1. rename default? No
-                # 2. enable multiple profiles? No
-                # 3. init git? No
-                # 4. use light theme? Yes
-                mock_confirm.side_effect = [False, False, False, True]
+                # 1. rename default? no
+                # 2. enable multiple profiles? no
+                # 3. init git? no
+                # 4. use light theme? yes
+                # 5. enable spell check? yes
+                mock_confirm.side_effect = [False, False, False, True, True]
                 result = wizard.run_setup()
 
         assert "profiles" in result
         assert "default" in result["profiles"]
         assert result["active_profile"] == "default"
+        assert result["profiles"]["default"]["spell_language"] == "en_US"
+        assert result["profiles"]["default"]["spell_check_enabled"] is True
 
     def test_fresh_rename_default(self, tmp_workspace):
         """Fresh install with renamed default profile."""
         with patch("click.prompt") as mock_prompt:
-            mock_prompt.side_effect = ["personal", str(tmp_workspace)]
+            mock_prompt.side_effect = ["personal", str(tmp_workspace), "en_US"]
             with patch("click.confirm") as mock_confirm:
-                # 1. rename? yes, 2. multi? no, 3. git? no, 4. light theme? yes
-                mock_confirm.side_effect = [True, False, False, True]
+                # 1. rename? yes, 2. multi? no, 3. git? no, 4. light theme? yes, 5. spell? yes
+                mock_confirm.side_effect = [True, False, False, True, True]
                 result = wizard.run_setup()
 
         assert "personal" in result["profiles"]
@@ -161,25 +162,29 @@ class TestRunSetupFresh:
 
         with patch("click.prompt") as mock_prompt:
             mock_prompt.side_effect = [
-                "work",  # additional profile names (asked before setup)
+                "work",          # additional profile names
                 str(tmp_workspace),  # default archive
-                str(work_dir),  # work archive
+                "en_US",         # default spell language
+                str(work_dir),   # work archive
+                "hu_HU",         # work spell language
             ]
             with patch("click.confirm") as mock_confirm:
                 # 1. rename default? no
                 # 2. enable multi? yes
                 # 3. init git for default? no
                 # 4. light theme for default? yes
-                # 5. setup others now? yes
-                # 6. init git for work? no
-                # 7. light theme for work? no (dark)
-                mock_confirm.side_effect = [False, True, False, True, True, False, False]
+                # 5. enable spell check for default? yes
+                # 6. setup others now? yes
+                # 7. init git for work? no
+                # 8. light theme for work? no (dark)
+                # 9. enable spell check for work? yes
+                mock_confirm.side_effect = [False, True, False, True, True, True, False, False, True]
                 result = wizard.run_setup()
 
         assert "default" in result["profiles"]
         assert "work" in result["profiles"]
-        # Resolve paths for comparison
         assert Path(result["profiles"]["work"]["archive_dir"]).resolve() == work_dir.resolve()
+        assert result["profiles"]["work"]["spell_language"] == "hu_HU"
 
 
 class TestRunSetupExisting:
@@ -195,18 +200,17 @@ class TestRunSetupExisting:
 
         with patch("click.prompt") as mock_prompt:
             mock_prompt.side_effect = [
-                "work",  # additional profile names
-                str(new_dir),  # work archive
+                "work",       # additional profile names
+                str(new_dir), # work archive
+                "en_US",      # work spell language
             ]
             with patch("click.confirm") as mock_confirm:
-                # 1. rename default? no, 2. add more? yes, 3. git? no, 4. light theme? yes
-                mock_confirm.side_effect = [False, True, False, True]
+                # 1. rename default? no, 2. add more? yes, 3. git? no, 4. light theme? yes, 5. spell? yes
+                mock_confirm.side_effect = [False, True, False, True, True]
                 result = wizard.run_setup(existing_profiles=existing)
 
-        # Existing profiles preserved
         assert "default" in result["profiles"]
         assert result["profiles"]["default"]["archive_dir"] == "/home/user/Writing"
-        # New profile added
         assert "work" in result["profiles"]
         assert result["profiles"]["work"]["archive_dir"] == str(new_dir)
 


### PR DESCRIPTION
**Related Issue:**  
Fixes #4 

**Description of Changes:**  
- Spell check now supports 80+ languages powered by hunspell, including Hungarian, Arabic, Polish, French, and many more. Language is set per profile during setup and can be changed any time in manage profiles.
- Spell check language selection is part of the setup wizard and the new profile flow.
- Existing users are prompted to set a language on first launch after upgrading, with the option to configure each profile individually.
- `--languages` flag lists all supported language codes with names.
- Spellcheck settings persist per profile.
- Spell check on/off toggle added to edit and new profile modals (`ctrl+k`).
- SPELL CHECK section added to `--reference`.

**Additional Notes:**  
